### PR TITLE
Make resource compatible with Bitbucket 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:edge
+FROM alpine:3.13.2
 
 RUN apk --update add \
   ca-certificates \

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ It will accept a regular expression as determined by [egrep](http://linuxcommand
 * `rebuild_phrase`: *Optional (default: test this please).* Regular expression as determined by [egrep](http://linuxcommand.org/man_pages/egrep1.html) will match all comments in pull request overview.
 If a match is found the pull request will be rebuilt.
 
+* `debug`: *Optional (default: false).* If set to `true` the bash tracing (`set -x`) will be enabled for the `in`, `out` and `check` scripts.
+
 ## Behavior
 
 ### `check`: Search for pull requests to build.
@@ -131,6 +133,7 @@ resources:
     username: {{bitbucket-username}}
     password: {{bitbucket-password}}
     uri: https://bitbucket.exemple.net/scm/exemple-project/exemple-repo.git
+    debug: true
 
 jobs:
 - name: test pull request

--- a/assets/check
+++ b/assets/check
@@ -24,6 +24,12 @@ payload=$(tmpfile request)
 
 cat > "$payload" <&0
 
+enable_debug=$(jq -r '.source.debug // false' < ${payload})
+if [ "${enable_debug}" = "true" ]; then
+  echo "Enable debug mode"
+  set -x
+fi
+
 log "Configuring git credentials"
 load_pubkey "$payload"
 
@@ -68,7 +74,7 @@ pull_requests=$(jq -r '.[] | [.id, .fromRef.latestCommit, .toRef.latestCommit, .
 if [ -n "$pull_requests" ]; then
   # Check if the current version is still valid
   if [[ "$current_change" -gt 0 ]] && (jq -e --argjson version "$current_version" '.[] | select(
-    .id == (($version.id//0)|tonumber) 
+    .id == (($version.id//0)|tonumber)
     and .fromRef.latestCommit == $version.from
     and .toRef.latestCommit == $version.to)' > /dev/null <<< "$pull_requests_json"); then
       versions="[$current_version]"

--- a/assets/helpers/git.sh
+++ b/assets/helpers/git.sh
@@ -94,9 +94,11 @@ pullrequest_metadata() {
   # $1: pull request number
   # $2: pull request repository
   # $3: skip ssl verification
+  # $4: source_commit
+  # $5: target_commit
 
-  local source_commit=$(git rev-list --parents -1 $(git rev-parse HEAD) | awk '{print $3}')
-  local target_commit=$(git rev-list --parents -1 $(git rev-parse HEAD) | awk '{print $2}')
+  local source_commit=$4
+  local target_commit=$5
 
   jq -n "[]" | \
     add_pullrequest_metadata_basic "$1" "$2" "$3" | \

--- a/assets/in
+++ b/assets/in
@@ -97,11 +97,6 @@ log "Cloning $uri in $destination"
 git clone $depthflag "$uri" "$destination"
 cd "$destination"
 
-# TODO cleanup
-#branch="pull-requests/${prq_id}/merge"
-#git fetch $depthflag origin "+refs/${branch}:refs/remotes/origin/${branch}"
-#git checkout -B $branch origin/$branch
-
 git fetch $depthflag origin "${prq_from_branch}"
 git checkout -B "${prq_from_branch}" "origin/${prq_from_branch}"
 
@@ -148,15 +143,6 @@ fi
 if [ "$disable_git_lfs" != "true" ]; then
   git submodule foreach "git lfs fetch && git lfs checkout"
 fi
-
-# calculate source and target commit
-# TODO cleanup
-#source_commit=$(git rev-list --parents -1 $ref | awk '{print $3}')
-#echo "Using source commit: ${source_commit}"
-
-# TODO cleanup
-#target_commit=$(git rev-list --parents -1 $ref | awk '{print $2}')
-#echo "Using target commit: ${target_commit}"
 
 if [ -z "$prq_from" ]; then
   log "Unable to determine source commit from merge commit $ref. Please verify depth configuration."

--- a/assets/in
+++ b/assets/in
@@ -32,7 +32,7 @@ cat > "$payload" <&0
 
 enable_debug=$(jq -r '.source.debug // false' < ${payload})
 if [ "${enable_debug}" = "true" ]; then
-  echo "Enable debug mode"
+  log "Enable debug mode"
   set -x
 fi
 
@@ -54,6 +54,27 @@ prq_id=$(jq -r '.version.id // ""' < "$payload")
 prq_date=$(jq -r '.version.date // ""' < "$payload")
 prq_change=$(jq -r '.version.change // ""' < "$payload")
 
+# parse uri and retrieve host
+uri_parser "$uri"
+repo_host="${uri_schema}://${uri_address}"
+repo_host=${repo_host}$(getBasePathOfBitbucket)
+
+# determine repository name for calling REST api
+repo_name=$(basename "$uri" | sed "s/.git$//")
+repo_project=$(basename $(dirname "$uri"))
+
+# verify target branch of prq
+prq=$(bitbucket_pullrequest "$repo_host" "$repo_project" "$repo_name" "$prq_id" "" "$skip_ssl_verification")
+
+prq_from=$(echo "$prq" | jq -r '.fromRef.latestCommit')
+prq_from_branch=$(echo "$prq" | jq -r '.fromRef.displayId')
+prq_target=$(echo "$prq" | jq -r '.toRef.latestCommit')
+prq_target_branch=$(echo "$prq" | jq -r '.toRef.displayId')
+
+log "Detected branches"
+log "From: ${prq_from_branch} (${prq_from})"
+log "Target: ${prq_target_branch} (${prq_target})"
+
 configure_git_ssl_verification "$skip_ssl_verification"
 configure_git_global "${git_config_payload}"
 
@@ -72,14 +93,17 @@ if test "$depth" -gt 0 2> /dev/null; then
   depthflag="--depth $depth"
 fi
 
-branch="pull-requests/${prq_id}/merge"
-
 log "Cloning $uri in $destination"
 git clone $depthflag "$uri" "$destination"
 cd "$destination"
 
-git fetch $depthflag origin "+refs/${branch}:refs/remotes/origin/${branch}"
-git checkout -B $branch origin/$branch
+# TODO cleanup
+#branch="pull-requests/${prq_id}/merge"
+#git fetch $depthflag origin "+refs/${branch}:refs/remotes/origin/${branch}"
+#git checkout -B $branch origin/$branch
+
+git fetch $depthflag origin "${prq_from_branch}"
+git checkout -B "${prq_from_branch}" "origin/${prq_from_branch}"
 
 ref=$(git rev-parse HEAD)
 
@@ -126,45 +150,38 @@ if [ "$disable_git_lfs" != "true" ]; then
 fi
 
 # calculate source and target commit
-source_commit=$(git rev-list --parents -1 $ref | awk '{print $3}')
-target_commit=$(git rev-list --parents -1 $ref | awk '{print $2}')
+# TODO cleanup
+#source_commit=$(git rev-list --parents -1 $ref | awk '{print $3}')
+#echo "Using source commit: ${source_commit}"
 
-if [ -z "$source_commit" ]; then
+# TODO cleanup
+#target_commit=$(git rev-list --parents -1 $ref | awk '{print $2}')
+#echo "Using target commit: ${target_commit}"
+
+if [ -z "$prq_from" ]; then
   log "Unable to determine source commit from merge commit $ref. Please verify depth configuration."
   exit 1
 fi
 
-if [ -z "$target_commit" ]; then
+if [ -z "$prq_target" ]; then
   log "Unable to determine target commit from merge commit $ref. Please verify depth configuration."
   exit 1
 fi
 
-# parse uri and retrieve host
-uri_parser "$uri"
-repo_host="${uri_schema}://${uri_address}"
-repo_host=${repo_host}$(getBasePathOfBitbucket)
-
-# determine repository name for calling REST api
-repo_name=$(basename "$uri" | sed "s/.git$//")
-repo_project=$(basename $(dirname "$uri"))
-
-# verify target branch of prq
-prq=$(bitbucket_pullrequest "$repo_host" "$repo_project" "$repo_name" "$prq_id" "" "$skip_ssl_verification")
-
 if [ "$prq" != "ERROR" ]; then
-  branch=$(echo "$prq" | jq -r '.fromRef.displayId')
+  from_branch=$(echo "$prq" | jq -r '.fromRef.displayId')
 fi
 
 # expose configuration of pull request that can be used in container
 git config --add pullrequest.id $prq_id
-git config --add pullrequest.source $source_commit
-git config --add pullrequest.target $target_commit
+git config --add pullrequest.source $prq_from
+git config --add pullrequest.target $prq_target
 git config --add pullrequest.merge $ref
 git config --add pullrequest.date "$prq_date"
 git config --add pullrequest.change "$prq_change"
-git config --add pullrequest.branch "$branch"
+git config --add pullrequest.branch "$from_branch"
 
 jq -n "{
   version: $(jq '.version' < "$payload"),
-  metadata: $(pullrequest_metadata "$prq_id" "$uri" "$skip_ssl_verification")
+  metadata: $(pullrequest_metadata "$prq_id" "$uri" "$skip_ssl_verification" "$prq_from" "$prq_target")
 }" >&3

--- a/assets/in
+++ b/assets/in
@@ -30,6 +30,12 @@ payload=$(tmpfile request)
 
 cat > "$payload" <&0
 
+enable_debug=$(jq -r '.source.debug // false' < ${payload})
+if [ "${enable_debug}" = "true" ]; then
+  echo "Enable debug mode"
+  set -x
+fi
+
 load_pubkey "$payload"
 configure_credentials "$payload"
 
@@ -148,7 +154,6 @@ prq=$(bitbucket_pullrequest "$repo_host" "$repo_project" "$repo_name" "$prq_id" 
 if [ "$prq" != "ERROR" ]; then
   branch=$(echo "$prq" | jq -r '.fromRef.displayId')
 fi
-
 
 # expose configuration of pull request that can be used in container
 git config --add pullrequest.id $prq_id

--- a/assets/out
+++ b/assets/out
@@ -30,6 +30,12 @@ payload=$(tmpfile request)
 
 cat > "$payload" <&0
 
+enable_debug=$(jq -r '.source.debug // false' < ${payload})
+if [ "${enable_debug}" = "true" ]; then
+  echo "Enable debug mode"
+  set -x
+fi
+
 load_pubkey "$payload"
 configure_credentials "$payload"
 

--- a/assets/out
+++ b/assets/out
@@ -118,10 +118,9 @@ case "$status" in
     exit 1
 esac
 
-# TODO
 # set build status on commit in bitbucket, this has to be the latest source commit or the pull request won't pick it up
-source_commit=$(git config --get pullrequest.source | cat)
-target_commit=$(git config --get pullrequest.target | cat)
+source_commit=$(git config --get pullrequest.source)
+target_commit=$(git config --get pullrequest.target)
 
 # determine repository name for calling REST api
 repo_name=$(basename "$uri" | sed "s/.git$//")

--- a/assets/out
+++ b/assets/out
@@ -118,9 +118,10 @@ case "$status" in
     exit 1
 esac
 
+# TODO
 # set build status on commit in bitbucket, this has to be the latest source commit or the pull request won't pick it up
-source_commit=$(git rev-list --parents -1 $merge_commit | awk '{print $3}')
-target_commit=$(git rev-list --parents -1 $merge_commit | awk '{print $2}')
+source_commit=$(git config --get pullrequest.source | cat)
+target_commit=$(git config --get pullrequest.target | cat)
 
 # determine repository name for calling REST api
 repo_name=$(basename "$uri" | sed "s/.git$//")
@@ -202,5 +203,5 @@ jq -n "{
     date: \"$prq_verify_date\",
     change: \"$prq_change\"
   },
-  metadata: $(pullrequest_metadata "$prq_number" "$uri" "$skip_ssl_verification")
+  metadata: $(pullrequest_metadata "$prq_number" "$uri" "$skip_ssl_verification" "$source_commit" "$target_commit")
 }" >&3


### PR DESCRIPTION
The PR in general restores the compatibility with Bitbucket 7+ using the REST API instead of the Git refs. It is in an early but working stage and might need further cleanup/refactoring.

Code review and advice is pretty much appreciated.

The PR also adds a config option (`debug`) to the resource to turn on bash tracing.

Fixes #3 